### PR TITLE
MySQLのコンテナが起動しない問題を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
         networks:
             - sail
     redis:
-        image: 'redis:alpine'
+        image: 'redis:6.2.5-alpine'
         ports:
             - '${FORWARD_REDIS_PORT:-6379}:6379'
         volumes:
@@ -59,7 +59,7 @@ services:
     #     networks:
     #         - sail
     mailhog:
-        image: 'mailhog/mailhog:latest'
+        image: 'mailhog/mailhog:v1.0.1'
         ports:
             - 1025:1025
             - 8025:8025

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     #     depends_on:
     #         - laravel.test
     mysql:
-        image: 'mysql:8.0'
+        image: 'mysql:8.0.21'
         ports:
             - '${FORWARD_DB_PORT:-3306}:3306'
         environment:


### PR DESCRIPTION
## 概要
```
$ sail up
... 割愛

mysql_1         | 2021-08-28 00:23:03+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.26-1debian10 started.
mysql_1         | 2021-08-28 00:23:03+00:00 [ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
mysql_1         |     Remove MYSQL_USER="root" and use one of the following to control the root user password:
mysql_1         |     - MYSQL_ROOT_PASSWORD
mysql_1         |     - MYSQL_ALLOW_EMPTY_PASSWORD
mysql_1         |     - MYSQL_RANDOM_ROOT_PASSWORD
laravel-quiz-app_mysql_1 exited with code 1
```
上記のエラーが出ていることを確認した。
どうやらこの影響らしい。
https://github.com/docker-library/mysql/pull/749

> This broke Laravel Sail: https://github.com/laravel/framework/issues/36647

まさに壊れた／(^o^)＼

> This commit will break all services using root user. Please update doc.

とのことなので、このリポジトリの内容も修正する。

### 状況まとめ
- mysqlのイメージで`MYSQL_USER`にrootを指定するとエラーが出るようになった
  - `mysql:8.0.23`から発生する
  - https://github.com/docker-library/mysql/pull/749
- Laravel sail のIssueでは、mysqlのイメージを固定するような提案がある
  - https://github.com/laravel/sail/issues/70

##  検討
### mysqlコンテナの環境変数に`MYSQL_USER` を指定しないという手はアリか？
結論：現時点ではナシ。

- mysql側は`MYSQL_USER`はroot以外のユーザーに使うことを想定している
- Laravel sail側は`.env`でユーザー名を差し込みたいが、rootの指定をナシにするという制御を入れづらい

1番良いのは、rootとは別で専用のユーザーを作るということになるが、開発環境なのでそこまで頑張る必要もないと判断した。
