### PR TITLE
Arm64(M1macなど)の場合にmysqlのimageが取得できない問題に対応

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,27 +45,27 @@ services:
             - './docker/mysql/my.cnf:/etc/mysql/conf.d/my.cnf'
         networks:
             - sail
-    redis:
-        image: 'redis:6.2.5-alpine'
-        ports:
-            - '${FORWARD_REDIS_PORT:-6379}:6379'
-        volumes:
-            - 'sailredis:/data'
-        networks:
-            - sail
+    # redis:
+    #     image: 'redis:6.2.5-alpine'
+    #     ports:
+    #         - '${FORWARD_REDIS_PORT:-6379}:6379'
+    #     volumes:
+    #         - 'sailredis:/data'
+    #     networks:
+    #         - sail
     # memcached:
     #     image: 'memcached:alpine'
     #     ports:
     #         - '11211:11211'
     #     networks:
     #         - sail
-    mailhog:
-        image: 'mailhog/mailhog:v1.0.1'
-        ports:
-            - 1025:1025
-            - 8025:8025
-        networks:
-            - sail
+    # mailhog:
+    #     image: 'mailhog/mailhog:v1.0.1'
+    #     ports:
+    #         - 1025:1025
+    #         - 8025:8025
+    #     networks:
+    #         - sail
 networks:
     sail:
         driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
             - sail
         depends_on:
             - mysql
-            - redis
+            # - redis
             # - selenium
     # selenium:
     #     image: 'selenium/standalone-chrome'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     #     depends_on:
     #         - laravel.test
     mysql:
+        platform: linux/x86_64
         image: 'mysql:8.0.21'
         ports:
             - '${FORWARD_DB_PORT:-3306}:3306'


### PR DESCRIPTION
## 概要
以下のようなエラーが出るため対処する
```
$ sail up -d
[+] Running 0/8
⠙ mysql Pulling 4.1s
⠙ redis Pulling 4.1s
⠸ 552d1f2373af Downloading 428.4kB/2... 1.3s
⠸ 08b93f529d04 Download complete 1.3s
⠸ 31ad70389ba9 Downloading 68.94kB/3... 1.3s
⠸ a9a83831f84e Waiting 1.3s
⠸ 4d9cb837bbdd Waiting 1.3s
⠸ d55efbe4c13d Waiting 1.3s
no matching manifest for linux/arm64/v8 in the manifest list entries
```

## 行ったこと
- MySQL用のコンテナにplatformを追記
- Redis, mailhugなど利用しないコンテナをコメントアウト

## 動作確認
macOSそれぞれで `docker compose up -d`（`sail up -d`） を行う

- [x] x86_64
- [x] arm64 (持ってないのでできない.. 欲しい..)