### PR TITLE
laravel/sailを1.15にバージョンアップ

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "facade/ignition": "^2.5",
         "fakerphp/faker": "^1.9.1",
-        "laravel/sail": "^1.13",
+        "laravel/sail": "^1.15",
         "mockery/mockery": "^1.4.2",
         "nunomaduro/collision": "^5.0",
         "phpunit/phpunit": "^9.3.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "782ba1114cedc3c0baf9b2bda55352bf",
+    "content-hash": "e3172ec9921a3e3964d4e1d824f5ca8b",
     "packages": [
         {
             "name": "brick/math",
@@ -5847,16 +5847,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.13.5",
+            "version": "v1.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "aeb6eeb55b22c328d2f301145b97288127691d48"
+                "reference": "2fe64c0b45a3af56cac0af638c8020a8adc860d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/aeb6eeb55b22c328d2f301145b97288127691d48",
-                "reference": "aeb6eeb55b22c328d2f301145b97288127691d48",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/2fe64c0b45a3af56cac0af638c8020a8adc860d7",
+                "reference": "2fe64c0b45a3af56cac0af638c8020a8adc860d7",
                 "shasum": ""
             },
             "require": {
@@ -5903,7 +5903,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2022-02-17T19:59:03+00:00"
+            "time": "2022-07-21T14:33:56+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -7905,5 +7905,5 @@
         "php": "^7.3|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
## 概要
Ubuntu 21.10だと、ondrejさんのppaあたりでエラーになるらしい。

Release v1.15.1 · laravel/sail
https://github.com/laravel/sail/releases/tag/v1.15.1
sail のバージョンを更新して、対処する。

## 動作確認
```
masa@MacBookPro laravel-quiz-app % sail up -d
[+] Running 0/1
 ⠿ laravel.test Error                                                                                                                                                                 0.2s
[+] Building 31.8s (7/16)
[+] Building 200.4s (17/17) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                  0.0s
 => => transferring dockerfile: 2.95kB                                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                       0.0s
 => [internal] load build context                                                                                                                                                     0.0s
 => => transferring context: 875B                                                                                                                                                     0.0s
 => [ 1/12] FROM docker.io/library/ubuntu:20.04                                                                                                                                       0.0s
 => CACHED [ 2/12] WORKDIR /var/www/html                                                                                                                                              0.0s
 => [ 3/12] RUN ln -snf /usr/share/zoneinfo/UTC /etc/localtime && echo UTC > /etc/timezone                                                                                            0.1s
 => [ 4/12] RUN apt-get update     && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2     && mkdir -p ~/.gnupg   197.3s
 => [ 5/12] RUN update-alternatives --set php /usr/bin/php8.0                                                                                                                         0.2s
 => [ 6/12] RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0                                                                                                                     0.2s
 => [ 7/12] RUN groupadd --force -g 20 sail                                                                                                                                           0.2s
 => [ 8/12] RUN useradd -ms /bin/bash --no-user-group -g 20 -u 1337 sail                                                                                                              0.3s
 => [ 9/12] COPY start-container /usr/local/bin/start-container                                                                                                                       0.0s
 => [10/12] COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf                                                                                                             0.0s
 => [11/12] COPY php.ini /etc/php/8.0/cli/conf.d/99-sail.ini                                                                                                                          0.0s
 => [12/12] RUN chmod +x /usr/local/bin/start-container                                                                                                                               0.1s
 => exporting to image                                                                                                                                                                1.8s
 => => exporting layers                                                                                                                                                               1.8s
 => => writing image sha256:33a9761cf8dce01a55945ad68955096573228083e1e2dbe0a90b11be07e080f5                                                                                          0.0s
 => => naming to sail-8.0/app                                                                                                                                                         0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
[+] Running 3/3
 ⠿ Network laravel-quiz-app_sail              Created                                                                                                                                 0.0s
 ⠿ Container laravel-quiz-app-mysql-1         Started                                                                                                                                 0.3s
 ⠿ Container laravel-quiz-app-laravel.test-1  Started
```
ok