### PR TITLE
sailのバージョンを更新

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "facade/ignition": "^2.5",
         "fakerphp/faker": "^1.9.1",
-        "laravel/sail": "^1.15",
+        "laravel/sail": "^1.16",
         "mockery/mockery": "^1.4.2",
         "nunomaduro/collision": "^5.0",
         "phpunit/phpunit": "^9.3.3"


### PR DESCRIPTION
## 概要
sailでaptの実行が失敗している問題があった。
phpをインストールする時に、オンドレイさんのPPAを参照できない問題を修正している模様。

Release v1.16.5 · laravel/sail
https://github.com/laravel/sail/releases/tag/v1.16.5
（ppaのための公開鍵を用意する方法を、yarnなどの公開鍵の用意の方法と同じ方法に合わせたらしい。）

***** The main PPA for supported PHP versions with many PECL ext... : Ondřej Surý
https://launchpad.net/~ondrej/+archive/ubuntu/php